### PR TITLE
Update dateUtils.ts

### DIFF
--- a/apps/frontend/src/utils/dateUtils.ts
+++ b/apps/frontend/src/utils/dateUtils.ts
@@ -5,7 +5,7 @@ export const formatDistanceToNow = (date: Date): string => {
   );
 
   if (diffInSeconds < 60) {
-    return "just now";
+    return "just n
   }
 
   const diffInMinutes = Math.floor(diffInSeconds / 60);


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
**What was changed**
- In `apps/frontend/src/utils/dateUtils.ts` the helper `formatDistanceToNow` was modified.
- The string returned for dates that are less than 60 seconds old was altered from the full phrase **“just now”** to the truncated text **“just n”**.

**Functional impact**
- Calls to `formatDistanceToNow` (used throughout the frontend to display relative timestamps) will now show an incomplete label for very recent events. Instead of the user‑friendly “just now”, the UI will render “just n”, which is likely unintended and will affect the readability of time‑ago displays.
<!-- kody-pr-summary:end -->