### PR TITLE
Sahil gupta584 patch 5

### DIFF
--- a/apps/frontend/src/utils/dateUtils.ts
+++ b/apps/frontend/src/utils/dateUtils.ts
@@ -5,7 +5,7 @@ export const formatDistanceToNow = (date: Date): string => {
   );
 
   if (diffInSeconds < 60) {
-    return "just now";
+    return "just n
   }
 
   const diffInMinutes = Math.floor(diffInSeconds / 60);

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -3,7 +3,7 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
-export default defineConfig(() => {
+export defau
   return {
     plugins: [
       TanStackRouterVite({ target: "react", autoCodeSplitting: true }),


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
**Summary of changes**

- **`apps/frontend/src/utils/dateUtils.ts`**  
  - The helper `formatDistanceToNow` now returns the string **`"just n"`** when the time difference is less than 60 seconds, replacing the previous `"just now"` message.

- **`apps/frontend/vite.config.ts`**  
  - The Vite configuration export line was altered from the full `export default defineConfig(() => {` to a truncated `export defau`, cutting off the rest of the statement.

**Functional impact**

- The UI label for very recent timestamps will show an incomplete/incorrect phrase (`"just n"` instead of `"just now"`).  
- The Vite configuration file is syntactically invalid, which will prevent the development server and production builds from starting until the export statement is restored
<!-- kody-pr-summary:end -->