### PR TITLE
Sahil gupta584 patch 5

### DIFF
--- a/apps/frontend/src/utils/dateUtils.ts
+++ b/apps/frontend/src/utils/dateUtils.ts
@@ -5,7 +5,7 @@ export const formatDistanceToNow = (date: Date): string => {
   );
 
   if (diffInSeconds < 60) {
-    return "just now";
+    return "just n
   }
 
   const diffInMinutes = Math.floor(diffInSeconds / 60);

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -3,7 +3,7 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
-export default defineConfig(() => {
+export defau
   return {
     plugins: [
       TanStackRouterVite({ target: "react", autoCodeSplitting: true }),


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
**Summary of changes**

1. **Date utility (`apps/frontend/src/utils/dateUtils.ts`)**  
   - The human‑readable label that is returned when a date is less than 60 seconds old was altered.  
   - The original return value **`"just now"`** was replaced with the incomplete string **`"just n"`**.

2. **Vite configuration (`apps/frontend/vite.config.ts`)**  
   - The `export default defineConfig(() => {` statement that initializes the Vite configuration was unintentionally truncated to **`export defau`**, removing the rest of the line.

**Functional impact**

- Calls to `formatDistanceToNow` will now display the truncated text `"just n"` for very recent timestamps instead of the intended `"just now"`.  
- The Vite configuration file no longer exports a valid configuration object, which will cause a syntax error and prevent the frontend project from building or running correctly.
<!-- kody-pr-summary:end -->