### PR TITLE
Sahil gupta584 patch 5

### DIFF
--- a/apps/frontend/src/utils/dateUtils.ts
+++ b/apps/frontend/src/utils/dateUtils.ts
@@ -5,7 +5,7 @@ export const formatDistanceToNow = (date: Date): string => {
   );
 
   if (diffInSeconds < 60) {
-    return "just now";
+    return "just n
   }
 
   const diffInMinutes = Math.floor(diffInSeconds / 60);

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -3,7 +3,7 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
-export default defineConfig(() => {
+export defau
   return {
     plugins: [
       TanStackRouterVite({ target: "react", autoCodeSplitting: true }),


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
**Summary of changes**

| File | Change | Functional impact |
|------|--------|--------------------|
| `apps/frontend/src/utils/dateUtils.ts` | The string returned for timestamps less than 60 seconds was altered from **`"just now"`** to **`"just n"`**. | Users will see an incomplete “just n” message instead of the intended “just now” when an event occurred moments ago. |
| `apps/frontend/vite.config.ts` | The Vite configuration’s default export line was truncated from **`export default defineConfig(() => {`** to **`export defau`**. | The Vite build script now contains a syntax error, causing the development server and production builds to fail. |

**Overall purpose**

The patch unintentionally introduced typographical errors in two core files:

1. It broke the human‑readable time‑ago formatting by shortening the “just now” label.
2. It corrupted the Vite configuration export, preventing the frontend project from compiling or running.

No functional improvements or bug fixes are present; instead, the changes degrade both UI output and build stability.
<!-- kody-pr-summary:end -->