### PR TITLE
Sahil gupta584 patch 5

### DIFF
--- a/apps/frontend/src/utils/dateUtils.ts
+++ b/apps/frontend/src/utils/dateUtils.ts
@@ -5,7 +5,7 @@ export const formatDistanceToNow = (date: Date): string => {
   );
 
   if (diffInSeconds < 60) {
-    return "just now";
+    return "just n
   }
 
   const diffInMinutes = Math.floor(diffInSeconds / 60);

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -3,7 +3,7 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
-export default defineConfig(() => {
+export defau
   return {
     plugins: [
       TanStackRouterVite({ target: "react", autoCodeSplitting: true }),


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
**Summary of changes**

1. **`apps/frontend/src/utils/dateUtils.ts`**  
   * The helper `formatDistanceToNow` now returns the string **`"just n"`** for timestamps that are less than 60 seconds old, instead of the previous **`"just now"`**. This alters the wording shown to users for very recent events.

2. **`apps/frontend/vite.config.ts`**  
   * The Vite configuration’s default export line was changed from the full statement `export default defineConfig(() => {` to a truncated form `export defau`. This modifies how the Vite configuration is exported (though the line is now incomplete).

**Functional impact**

* The date‑formatting utility will display a shortened/partial label (“just n”) for sub‑minute differences, affecting UI messages that rely on this helper.  
* The Vite configuration export is now syntactically incomplete, which will prevent the frontend build from being correctly generated until the export statement is restored.
<!-- kody-pr-summary:end -->