### PR TITLE
Sahil gupta584 patch 5

### DIFF
--- a/apps/frontend/src/utils/dateUtils.ts
+++ b/apps/frontend/src/utils/dateUtils.ts
@@ -5,7 +5,7 @@ export const formatDistanceToNow = (date: Date): string => {
   );
 
   if (diffInSeconds < 60) {
-    return "just now";
+    return "just n
   }
 
   const diffInMinutes = Math.floor(diffInSeconds / 60);

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -3,7 +3,7 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
-export default defineConfig(() => {
+export defau
   return {
     plugins: [
       TanStackRouterVite({ target: "react", autoCodeSplitting: true }),


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request makes two small text changes in the frontend code:

- In `apps/frontend/src/utils/dateUtils.ts`, the message returned for dates that are less than a minute old is altered from `"just now"` to `"just n"`.
- In `apps/frontend/vite.config.ts`, the opening line of the default export is changed from `export default defineConfig(() => {` to `export defau`, truncating the statement.

These edits modify the recent‑timestamp display text and the Vite configuration export statement.
<!-- kody-pr-summary:end -->