### PR TITLE
Sahil gupta584 patch 5

### DIFF
--- a/apps/frontend/src/utils/dateUtils.ts
+++ b/apps/frontend/src/utils/dateUtils.ts
@@ -5,7 +5,7 @@ export const formatDistanceToNow = (date: Date): string => {
   );
 
   if (diffInSeconds < 60) {
-    return "just now";
+    return "just n
   }
 
   const diffInMinutes = Math.floor(diffInSeconds / 60);

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -3,7 +3,7 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
-export default defineConfig(() => {
+export defau
   return {
     plugins: [
       TanStackRouterVite({ target: "react", autoCodeSplitting: true }),


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request makes two small changes to the frontend code:

- In `apps/frontend/src/utils/dateUtils.ts`, the text returned for very recent timestamps is updated from `"just now"` to `"just n"`.
- In `apps/frontend/vite.config.ts`, the export statement is modified (the line now reads `export defau` instead of the full `export default defineConfig(() => {`).

These changes alter the wording used for recent date displays and adjust the Vite configuration export, though the latter appears to be truncated in the current diff.
<!-- kody-pr-summary:end -->