### PR TITLE
Sahil gupta584 patch 5

### DIFF
--- a/apps/frontend/src/utils/dateUtils.ts
+++ b/apps/frontend/src/utils/dateUtils.ts
@@ -5,7 +5,7 @@ export const formatDistanceToNow = (date: Date): string => {
   );
 
   if (diffInSeconds < 60) {
-    return "just now";
+    return "just n
   }
 
   const diffInMinutes = Math.floor(diffInSeconds / 60);

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -3,7 +3,7 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
-export default defineConfig(() => {
+export defau
   return {
     plugins: [
       TanStackRouterVite({ target: "react", autoCodeSplitting: true }),


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request modifies two files in the frontend:

- In `apps/frontend/src/utils/dateUtils.ts`, the string returned for timestamps that are less than a minute old is changed from `"just now"` to `"just n"`.
- In `apps/frontend/vite.config.ts`, the export statement is altered, changing `export default defineConfig(() => {` to `export defau`.

These changes affect the text displayed for recent relative dates and the way the Vite configuration is exported.
<!-- kody-pr-summary:end -->